### PR TITLE
Account for the fact that STATE_TRANSFERRING may happen 0 times. 

### DIFF
--- a/lib/har-driver-actor.js
+++ b/lib/har-driver-actor.js
@@ -275,6 +275,10 @@ var HarDriverActor = ActorClass(
   // Internals
 
   exposeToContentInternal: function(win) {
+    if (win.hasOwnProperty("HAR")) {
+      return;
+    }
+
     exportIntoContentScope(win, this.api, "HAR");
 
     let event = new win.MessageEvent("har-api-ready");
@@ -299,7 +303,7 @@ var HarDriverActor = ActorClass(
     let isTransferring = aFlag & Ci.nsIWebProgressListener.STATE_TRANSFERRING;
 
     let win = aProgress.DOMWindow;
-    if (isDocument && isTransferring) {
+    if (isDocument && (isTransferring || isStop)) {
       this.exposeToContentInternal(win);
     }
   })),


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIWebProgressListener):

> For any given request, onStateChange() is called once with the STATE_START flag, **zero or more times with the STATE_TRANSFERRING flag** or once with the STATE_REDIRECTING flag, and then finally once with the STATE_STOP flag.

Possibly fixes #18.
